### PR TITLE
Avoid seemingly-normative language

### DIFF
--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -136,7 +136,7 @@ they would prefer to receive. Servers SHOULD NOT send more tickets than
 TicketRequestContents.count, as clients will most likely discard any additional
 tickets. Servers SHOULD additionally place a limit on the number of tickets
 they are willing to send, to save resources. Therefore, the number of
-NewSessionTicket messages sent will be the minimum of the server's self-imposed
+NewSessionTicket messages sent will typically be the minimum of the server's self-imposed
 limit and TicketRequestContents.count.
 
 Servers that support ticket requests MUST NOT echo "ticket_request" in the EncryptedExtensions


### PR DESCRIPTION
I don't think any of this paragraph should have 2119 language in it. But, even overlooking that minor disagreement, it's important to avoid unintentional requirements. I think my edit guides well-meaning implementors, while making no guarantees.