### PR TITLE
Ticket request with separate resumption and new_session counts.

### DIFF
--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -91,11 +91,12 @@ therefore bound the number of parallel connections they initiate by the number o
 in their possession, or risk ticket re-use.
 - Connection racing: Happy Eyeballs V2 {{?RFC8305}} describes techniques for performing connection
 racing. The Transport Services Architecture implementation from {{?TAPS=I-D.ietf-taps-impl}} also describes
-how connections can race across interfaces and address families. In cases where clients have early
-data to send and want to minimize or avoid ticket re-use, unique tickets for each unique
-connection attempt are useful. Moreover, as some servers may implement single-use tickets (and even
-session ticket encryption keys), distinct tickets will be needed to prevent premature ticket
-invalidation by racing.
+how connections can race across interfaces and address families. In such cases, clients may use
+more than one ticket while racing connection attempts in order to establish one successful connection.
+Requesting multiple tickets a priori equips clients with enough tickets to initiate connection racing while
+avoiding ticket re-use and ensuring that their cache of tickets does not empty during such races.
+Moreover, as some servers may implement single-use tickets (and even session ticket encryption keys),
+distinct tickets will be needed to prevent premature ticket invalidation by racing.
 - Connection priming: In some systems, connections can be primed or bootstrapped by a centralized
 service or daemon for faster connection establishment. Requesting tickets on demand allows such
 services to vend tickets to clients to use for accelerated handshakes with early data. (Note that
@@ -175,9 +176,9 @@ and use tickets beyond common lifetime windows of, e.g., 24 hours. Despite ticke
 hints provided by servers, clients SHOULD dispose of pooled tickets after some reasonable
 amount of time that mimics the ticket rotation period.
 
-In some cases, a server may send NewSessionTicket messages immediately upon sending 
+In some cases, a server may send NewSessionTicket messages immediately upon sending
 the server Finished message rather than waiting for the client Finished. If the server
-has not verified the client's ownership of its IP address, e.g., with the TLS 
+has not verified the client's ownership of its IP address, e.g., with the TLS
 Cookie extension (see {{RFC8446}}; Section 4.2.2), an attacker may take advantage of this behavior to create
 an amplification attack proportional to the count value toward a target by performing a key
 exchange over UDP with spoofed packets. Servers SHOULD limit the number of NewSessionTicket messages they send until they have verified the client's ownership of its IP address.

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -79,10 +79,12 @@ ultimately derive from an initial full handshake.  Especially when the client
 was initially authenticated with a client certificate, that session may need to
 be refreshed from time to time.  Consequently, a server may periodically
 perform a full handshake even when the client presents a valid ticket for a
-session that is too old.  When that happens a client should replace all its
-cached tickets with fresh ones obtained from the full handshake.  The
-number of tickets the server should vend for a full handshake may therefore
-need to be larger than the number for routine resumption.
+session that is too old.  When that happens, it is possible that all tickets
+derived from the same original session are equally invalid.  A client avoids a
+full handshake on subsequent connections if it replaces all stored tickets with
+fresh values.  The number of tickets the server should vend for a full
+handshake may therefore need to be larger than the number for routine
+resumption.
 
 This document specifies a new TLS extension -- "ticket_request" -- that can be used
 by clients to express their desired number of session tickets. Servers can use this
@@ -110,7 +112,7 @@ in their possession, or risk ticket re-use.
 racing. The Transport Services Architecture implementation from {{?TAPS=I-D.ietf-taps-impl}} also describes
 how connections can race across interfaces and address families. In such cases, clients may use
 more than one ticket while racing connection attempts in order to establish one successful connection.
-Requesting multiple tickets a priori equips clients with enough tickets to initiate connection racing while
+Having  multiple tickets equips clients with enough tickets to initiate connection racing while
 avoiding ticket re-use and ensuring that their cache of tickets does not empty during such races.
 Moreover, as some servers may implement single-use tickets (and even session ticket encryption keys),
 distinct tickets will be needed to prevent premature ticket invalidation by racing.


### PR DESCRIPTION
This improves both happy eyeballs and ticket reuse.