### PR TITLE
Use two counters for fresh and resumed connections

### DIFF
--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -185,7 +185,7 @@ In that case, clients SHOULD send a resumption_count equal to the number
 of sessions they are attempting in parallel.
 
 When a client presenting a previously obtained ticket finds that the server
-nevertheless negotiates a fresh session, the client should assume that any
+nevertheless negotiates a fresh session, the client might assume that any
 other tickets associated with the same session as the presented ticket are also
 no longer valid for resumption.  This includes tickets obtained
 during the initial full handshake and all tickets subsequently obtained as

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -185,12 +185,12 @@ In that case, clients can send a resumption_count equal to the number of
 sessions they are attempting in parallel.
 
 When a client presenting a previously obtained ticket finds that the server
-nevertheless negotiates a fresh session, the client might assume that any
+nevertheless negotiates a fresh session, the client SHOULD assume that any
 other tickets associated with the same session as the presented ticket are also
 no longer valid for resumption.  This includes tickets obtained
 during the initial full handshake and all tickets subsequently obtained as
-part of subsequent resumptions.  Requesting more than one ticket in case a
-full handshake is forced by the server helps to keep the session cache primed.
+part of subsequent resumptions.  Requesting more than one ticket in cases when
+servers select a full handshake helps keep the session cache primed.
 
 Servers SHOULD NOT send more tickets than requested for the handshake type
 selected by the server (resumption or full handshake). Moreover, servers
@@ -201,10 +201,10 @@ of the server's self-imposed limit and the number requested.
 Servers MAY send additional tickets, up to the same limit, if the tickets
 that are originally sent are somehow invalidated.
 
-A server that supports ticket requests MAY echo the "ticket_request" extension
-in the EncryptedExtensions message. If present, it contains a single
-value, expected_count, indicating the number of tickets the server expects to
-send to the client.
+A server which supports and uses a client "ticket_request" extension MUST also send
+the "ticket_request" extension in the EncryptedExtensions message. The server
+"ticket_request" extension contains a single value, expected_count, indicating the
+number of tickets the server expects to send to the client.
 
 Servers MUST NOT send the "ticket_request" extension in ServerHello or HelloRetryRequest messages.
 A client MUST abort the connection with an "illegal_parameter" alert if the "ticket_request" extension

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -149,17 +149,6 @@ struct {
     uint8 new_session_count;
     uint8 resumption_count;
 } ClientTicketRequest;
-
-struct {
-    uint8 expected_count;
-} ServerTicketRequestHint;
-
-struct {
-    select (Handshake.msg_type) {
-        case client_hello: ClientTicketRequest;
-        case encrypted_extensions: ServerTicketRequestHint;
-    }
-} TicketRequestContents;
 ~~~
 
 new_session_count
@@ -169,10 +158,6 @@ negotiate a fresh session (full handshake).
 resumption_count
 : The number of tickets desired by the client when the server is willing to
 resume using the presented ticket.
-
-expected_count
-: The number of tickets the server expects to send in response to a client
-ticket_request extension.
 
 A client starting a fresh connection SHOULD set new_session_count to the desired
 number of session tickets and resumption_count to 0.
@@ -202,9 +187,18 @@ Servers MAY send additional tickets, up to the same limit, if the tickets
 that are originally sent are somehow invalidated.
 
 A server which supports and uses a client "ticket_request" extension MUST also send
-the "ticket_request" extension in the EncryptedExtensions message. The server
-"ticket_request" extension contains a single value, expected_count, indicating the
-number of tickets the server expects to send to the client.
+the "ticket_request" extension in the EncryptedExtensions message. It contains
+the following structure:
+
+~~~
+struct {
+    uint8 expected_count;
+} ServerTicketRequestHint;
+~~~
+
+expected_count
+: The number of tickets the server expects to send in response to a client
+ticket_request extension in this connection.
 
 Servers MUST NOT send the "ticket_request" extension in ServerHello or HelloRetryRequest messages.
 A client MUST abort the connection with an "illegal_parameter" alert if the "ticket_request" extension
@@ -212,7 +206,7 @@ is present in either of these messages.
 
 If a client receives a HelloRetryRequest, the presence (or absence) of the "ticket_request" extension
 MUST be maintained in the second ClientHello message. Moreover, if this extension is present, a client
-MUST NOT change the value of TicketRequestContents in the second ClientHello message.
+MUST NOT change the value of ClientTicketRequest in the second ClientHello message.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -152,12 +152,12 @@ struct {
 
 struct {
     uint8 expected_count;
-} ServerTicketRequest;
+} ServerTicketRequestHint;
 
 struct {
     select (Handshake.msg_type) {
         case client_hello: ClientTicketRequest;
-        case encrypted_extensions: ServerTicketRequest;
+        case encrypted_extensions: ServerTicketRequestHint;
     }
 } TicketRequestContents;
 ~~~

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -199,8 +199,7 @@ struct {
 ~~~
 
 expected_count
-: The number of tickets the server expects to send in response to a client
-ticket_request extension in this connection.
+: The number of tickets the server expects to send in this connection.
 
 Servers MUST NOT send the "ticket_request" extension in ServerHello or HelloRetryRequest messages.
 A client MUST abort the connection with an "illegal_parameter" alert if the "ticket_request" extension

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -167,7 +167,9 @@ without over-provisioning the client with excess tickets. However, clients
 which race multiple connections and place a separate ticket in each will
 ultimately end up with just the tickets from a single resumed session.
 In that case, clients can send a resumption_count equal to the number of
-sessions they are attempting in parallel.
+sessions they are attempting in parallel. (Clients which send a resumption_count
+less than the number of parallel connection attempts might end up with zero
+tickets.)
 
 When a client presenting a previously obtained ticket finds that the server
 nevertheless negotiates a fresh session, the client SHOULD assume that any

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -91,11 +91,12 @@ therefore bound the number of parallel connections they initiate by the number o
 in their possession, or risk ticket re-use.
 - Connection racing: Happy Eyeballs V2 {{?RFC8305}} describes techniques for performing connection
 racing. The Transport Services Architecture implementation from {{?TAPS=I-D.ietf-taps-impl}} also describes
-how connections can race across interfaces and address families. In cases where clients have early
-data to send and want to minimize or avoid ticket re-use, unique tickets for each unique
-connection attempt are useful. Moreover, as some servers may implement single-use tickets (and even
-session ticket encryption keys), distinct tickets will be needed to prevent premature ticket
-invalidation by racing.
+how connections can race across interfaces and address families. In such cases, clients may use
+more than one ticket while racing connection attempts in order to establish one successful connection.
+Requesting multiple tickets a priori equips clients with enough tickets to initiate connection racing while
+avoiding ticket re-use and ensuring that their cache of tickets does not empty during such races.
+Moreover, as some servers may implement single-use tickets (and even session ticket encryption keys),
+distinct tickets will be needed to prevent premature ticket invalidation by racing.
 - Connection priming: In some systems, connections can be primed or bootstrapped by a centralized
 service or daemon for faster connection establishment. Requesting tickets on demand allows such
 services to vend tickets to clients to use for accelerated handshakes with early data. (Note that
@@ -175,9 +176,9 @@ and use tickets beyond common lifetime windows of, e.g., 24 hours. Despite ticke
 hints provided by servers, clients SHOULD dispose of pooled tickets after some reasonable
 amount of time that mimics the ticket rotation period.
 
-In some cases, a server may send NewSessionTicket messages immediately upon sending 
+In some cases, a server may send NewSessionTicket messages immediately upon sending
 the server Finished message rather than waiting for the client Finished. If the server
-has not verified the client's ownership of its IP address, e.g., with the TLS 
+has not verified the client's ownership of its IP address, e.g., with the TLS
 Cookie extension (see {{RFC8446}}; Section 4.2.2), an attacker may take advantage of this behavior to create
 an amplification attack proportional to the count value toward a target by performing a key
 exchange over UDP with spoofed packets. Servers SHOULD limit the number of NewSessionTicket messages they send until they have verified the client's ownership of its IP address.

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -112,7 +112,7 @@ in their possession, or risk ticket re-use.
 racing. The Transport Services Architecture implementation from {{?TAPS=I-D.ietf-taps-impl}} also describes
 how connections can race across interfaces and address families. In such cases, clients may use
 more than one ticket while racing connection attempts in order to establish one successful connection.
-Having  multiple tickets equips clients with enough tickets to initiate connection racing while
+Having multiple tickets equips clients with enough tickets to initiate connection racing while
 avoiding ticket re-use and ensuring that their cache of tickets does not empty during such races.
 Moreover, as some servers may implement single-use tickets, distinct tickets prevent
 premature ticket invalidation by racing.

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -181,8 +181,8 @@ good choice that allows the server to replace each ticket with a fresh ticket,
 without over-provisioning the client with excess tickets. However, clients
 which race multiple connections and place a separate ticket in each will
 ultimately end up with just the tickets from a single resumed session.
-In that case, clients SHOULD send a resumption_count equal to the number
-of sessions they are attempting in parallel.
+In that case, clients can send a resumption_count equal to the number of
+sessions they are attempting in parallel.
 
 When a client presenting a previously obtained ticket finds that the server
 nevertheless negotiates a fresh session, the client might assume that any
@@ -198,6 +198,8 @@ SHOULD place a limit on the number of tickets they are willing to send, whether
 for full handshakes or resumptions, to save resources.  Therefore, the
 number of NewSessionTicket messages sent will typically be the minimum
 of the server's self-imposed limit and the number requested.
+Servers MAY send additional tickets, up to the same limit, if the tickets
+that are originally sent are somehow invalidated.
 
 A server that supports ticket requests MAY echo the "ticket_request" extension
 in the EncryptedExtensions message. If present, it contains a single

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -151,9 +151,13 @@ struct {
 } ClientTicketRequest;
 
 struct {
+    uint8 expected_count;
+} ServerTicketRequest;
+
+struct {
     select (Handshake.msg_type) {
         case client_hello: ClientTicketRequest;
-        case encrypted_extensions: uint8 expected_count;
+        case encrypted_extensions: ServerTicketRequest;
     }
 } TicketRequestContents;
 ~~~
@@ -177,8 +181,8 @@ good choice that allows the server to replace each ticket with a fresh ticket,
 without over-provisioning the client with excess tickets. However, clients
 which race multiple connections and place a separate ticket in each will
 ultimately end up with just the tickets from a single resumed session.
-In that case, a resumption_count commensurate with the number of parallel
-sessions would be used.
+In that case, clients SHOULD send a resumption_count equal to the number
+of sessions they are attempting in parallel.
 
 When a client presenting a previously obtained ticket finds that the server
 nevertheless negotiates a fresh session, the client should assume that any

--- a/draft-ietf-tls-ticketrequests.md
+++ b/draft-ietf-tls-ticketrequests.md
@@ -79,10 +79,12 @@ ultimately derive from an initial full handshake.  Especially when the client
 was initially authenticated with a client certificate, that session may need to
 be refreshed from time to time.  Consequently, a server may periodically
 perform a full handshake even when the client presents a valid ticket for a
-session that is too old.  When that happens a client should replace all its
-cached tickets with fresh ones obtained from the full handshake.  The
-number of tickets the server should vend for a full handshake may therefore
-need to be larger than the number for routine resumption.
+session that is too old.  When that happens, it is possible that all tickets
+derived from the same original session are equally invalid.  A client avoids a
+full handshake on subsequent connections if it replaces all stored tickets with
+fresh values.  The number of tickets the server should vend for a full
+handshake may therefore need to be larger than the number for routine
+resumption.
 
 This document specifies a new TLS extension -- "ticket_request" -- that can be used
 by clients to express their desired number of session tickets. Servers can use this
@@ -110,7 +112,7 @@ in their possession, or risk ticket re-use.
 racing. The Transport Services Architecture implementation from {{?TAPS=I-D.ietf-taps-impl}} also describes
 how connections can race across interfaces and address families. In such cases, clients may use
 more than one ticket while racing connection attempts in order to establish one successful connection.
-Requesting multiple tickets a priori equips clients with enough tickets to initiate connection racing while
+Having  multiple tickets equips clients with enough tickets to initiate connection racing while
 avoiding ticket re-use and ensuring that their cache of tickets does not empty during such races.
 Moreover, as some servers may implement single-use tickets (and even session ticket encryption keys),
 distinct tickets will be needed to prevent premature ticket invalidation by racing.


### PR DESCRIPTION
This is #18 without ticket re-use text. This also includes changes from #17.

The following table outlines the ticket request values for a a client that wants 
N tickets and always attempts to race a connection across K paths.

| Client Scenario | new_session_count value | resumption_count value |
| ------------- |:-------------:| -----:|
| N = 0 | 0 | 0 |
| Fresh handshake | N | 0 |
| Resumption attempt | N | K |

Did I get this right? Does this make sense? Should we put this in the document directly?